### PR TITLE
Fix serializer recursion handling and bump version to 1.0.3

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.vality.geck</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/src/main/java/dev/vality/geck/common/util/BinaryUtil.java
+++ b/common/src/main/java/dev/vality/geck/common/util/BinaryUtil.java
@@ -1,0 +1,16 @@
+package dev.vality.geck.common.util;
+
+import java.nio.ByteBuffer;
+
+public final class BinaryUtil {
+
+    private BinaryUtil() {
+    }
+
+    public static byte[] toByteArray(ByteBuffer buffer) {
+        ByteBuffer currentRange = buffer.slice();
+        byte[] bytes = new byte[currentRange.remaining()];
+        currentRange.get(bytes);
+        return bytes;
+    }
+}

--- a/filter/pom.xml
+++ b/filter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.vality.geck</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/migrator/pom.xml
+++ b/migrator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.vality.geck</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/migrator/src/main/java/dev/vality/geck/migrator/kit/BaseMigrationManager.java
+++ b/migrator/src/main/java/dev/vality/geck/migrator/kit/BaseMigrationManager.java
@@ -42,7 +42,7 @@ public class BaseMigrationManager implements MigrationManager {
                 throw new MigrationException("Not migrator for type: "+ mPoint.getMigrationType());
             }
             transitionSerSpec.setOutDef( ((i < mPoints.size() - 1) ? mPoints.get(i + 1).getSerializerDef() : serializerSpec.getOutDef()));
-            data = migrator.migrate(src, mPoint, transitionSerSpec);
+            data = migrator.migrate(data, mPoint, transitionSerSpec);
             transitionSerSpec.setInDef(mPoint.getSerializerDef());
         }
 

--- a/migrator/src/test/java/dev/vality/geck/migrator/kit/TestBaseMigrationManager.java
+++ b/migrator/src/test/java/dev/vality/geck/migrator/kit/TestBaseMigrationManager.java
@@ -25,6 +25,21 @@ public class TestBaseMigrationManager {
         Assert.assertEquals("A", res);
     }
 
+    @Test
+    public void shouldPassIntermediateMigrationResultToNextStep() throws MigrationException {
+        BaseMigrationStore migrationStore = new BaseMigrationStore(Arrays.asList(new MigrationPointProviderImpl(Arrays.asList(
+                new ThriftSpec(new ThriftDef(1, "t1"), new ThriftDef(2, "t2")),
+                new ThriftSpec(new ThriftDef(2, "t2"), new ThriftDef(3, "t2")),
+                new ThriftSpec(new ThriftDef(3, "t2"), new ThriftDef(4, "t3"))
+        ))));
+        BaseMigrationManager migrationManager =
+                new BaseMigrationManager(migrationStore, Arrays.asList(new AccumulatingMigrator()));
+
+        String res = migrationManager.migrate("A", new ThriftDef(1), new SerializerDef<>("TEST"));
+
+        Assert.assertEquals("A123", res);
+    }
+
     private static class MigrationPointProviderImpl implements MigrationPointProvider {
         private List<MigrationPoint> migrationPoints;
 
@@ -76,6 +91,19 @@ public class TestBaseMigrationManager {
         @Override
         public <I, O> O migrate(I data, MigrationPoint mPoint, SerializerSpec<I, O> serializerSpec) throws MigrationException {
             return serialize(data, serializerSpec, mPoint.getThriftSpec());
+        }
+
+        @Override
+        public String getMigrationType() {
+            return "TEST";
+        }
+    }
+
+    private static class AccumulatingMigrator implements Migrator {
+
+        @Override
+        public <I, O> O migrate(I data, MigrationPoint mPoint, SerializerSpec<I, O> serializerSpec) {
+            return (O) (String.valueOf(data) + ((MigrationSpecImpl) mPoint.getMigrationSpec()).getSpec().replace("TEST", ""));
         }
 
         @Override

--- a/migrator/src/test/java/dev/vality/geck/migrator/kit/TestBaseMigrationManager.java
+++ b/migrator/src/test/java/dev/vality/geck/migrator/kit/TestBaseMigrationManager.java
@@ -14,41 +14,46 @@ import java.util.stream.Collectors;
 public class TestBaseMigrationManager {
 
     @Test
-    public void test() throws MigrationException {
-        BaseMigrationStore migrationStore = new BaseMigrationStore(Arrays.asList(new MigrationPointProviderImpl(Arrays.asList(
+    public void shouldKeepSourceDataWhenMigratorDoesNotTransformIt() throws MigrationException {
+        BaseMigrationStore migrationStore =
+                new BaseMigrationStore(Arrays.asList(new MigrationPointProviderStub(Arrays.asList(
                 new ThriftSpec(new ThriftDef(1, "t1"), new ThriftDef(2, "t2")),
                 new ThriftSpec(new ThriftDef(2, "t2"), new ThriftDef(3, "t2")),
                 new ThriftSpec(new ThriftDef(3, "t2"), new ThriftDef(30, "t3"))
         ))));
-        BaseMigrationManager migrationManager = new BaseMigrationManager(migrationStore, Arrays.asList(new MigratorImpl()));
-        String res = migrationManager.migrate("A", new ThriftDef(1), new SerializerDef<>("TEST"));
-        Assert.assertEquals("A", res);
+        BaseMigrationManager migrationManager =
+                new BaseMigrationManager(migrationStore, Arrays.asList(new PassThroughMigrator()));
+
+        String result = migrationManager.migrate("A", new ThriftDef(1), new SerializerDef<>("TEST"));
+
+        Assert.assertEquals("A", result);
     }
 
     @Test
     public void shouldPassIntermediateMigrationResultToNextStep() throws MigrationException {
-        BaseMigrationStore migrationStore = new BaseMigrationStore(Arrays.asList(new MigrationPointProviderImpl(Arrays.asList(
+        BaseMigrationStore migrationStore =
+                new BaseMigrationStore(Arrays.asList(new MigrationPointProviderStub(Arrays.asList(
                 new ThriftSpec(new ThriftDef(1, "t1"), new ThriftDef(2, "t2")),
                 new ThriftSpec(new ThriftDef(2, "t2"), new ThriftDef(3, "t2")),
                 new ThriftSpec(new ThriftDef(3, "t2"), new ThriftDef(4, "t3"))
         ))));
         BaseMigrationManager migrationManager =
-                new BaseMigrationManager(migrationStore, Arrays.asList(new AccumulatingMigrator()));
+                new BaseMigrationManager(migrationStore, Arrays.asList(new StepNumberAppendingMigrator()));
 
-        String res = migrationManager.migrate("A", new ThriftDef(1), new SerializerDef<>("TEST"));
+        String result = migrationManager.migrate("A", new ThriftDef(1), new SerializerDef<>("TEST"));
 
-        Assert.assertEquals("A123", res);
+        Assert.assertEquals("A123", result);
     }
 
-    private static class MigrationPointProviderImpl implements MigrationPointProvider {
-        private List<MigrationPoint> migrationPoints;
+    private static class MigrationPointProviderStub implements MigrationPointProvider {
+        private final List<MigrationPoint> migrationPoints;
 
-        public MigrationPointProviderImpl(Collection<ThriftSpec> tSpecs) {
+        MigrationPointProviderStub(Collection<ThriftSpec> thriftSpecs) {
             AtomicInteger idx = new AtomicInteger();
             SerializerDef serializerDef = new SerializerDef("TEST");
-            migrationPoints = tSpecs.stream().map(thriftSpec -> {
+            migrationPoints = thriftSpecs.stream().map(thriftSpec -> {
                 int i = idx.incrementAndGet();
-                return new MigrationPoint(i, thriftSpec, serializerDef, new MigrationSpecImpl("TEST"+i));
+                return new MigrationPoint(i, thriftSpec, serializerDef, new TestMigrationSpec("TEST" + i));
             }).collect(Collectors.toList());
         }
 
@@ -68,10 +73,10 @@ public class TestBaseMigrationManager {
         }
     }
 
-    private static class MigrationSpecImpl implements MigrationSpec<String> {
-        private String spec;
+    private static class TestMigrationSpec implements MigrationSpec<String> {
+        private final String spec;
 
-        public MigrationSpecImpl(String spec) {
+        TestMigrationSpec(String spec) {
             this.spec = spec;
         }
 
@@ -86,7 +91,7 @@ public class TestBaseMigrationManager {
         }
     }
 
-    private static class MigratorImpl extends AbstractMigrator {
+    private static class PassThroughMigrator extends AbstractMigrator {
 
         @Override
         public <I, O> O migrate(I data, MigrationPoint mPoint, SerializerSpec<I, O> serializerSpec) throws MigrationException {
@@ -99,11 +104,12 @@ public class TestBaseMigrationManager {
         }
     }
 
-    private static class AccumulatingMigrator implements Migrator {
+    private static class StepNumberAppendingMigrator implements Migrator {
 
         @Override
         public <I, O> O migrate(I data, MigrationPoint mPoint, SerializerSpec<I, O> serializerSpec) {
-            return (O) (String.valueOf(data) + ((MigrationSpecImpl) mPoint.getMigrationSpec()).getSpec().replace("TEST", ""));
+            String stepNumber = ((TestMigrationSpec) mPoint.getMigrationSpec()).getSpec().replace("TEST", "");
+            return (O) (String.valueOf(data) + stepNumber);
         }
 
         @Override

--- a/migrator/src/test/java/dev/vality/geck/migrator/kit/TestBaseMigrationManager.java
+++ b/migrator/src/test/java/dev/vality/geck/migrator/kit/TestBaseMigrationManager.java
@@ -13,6 +13,10 @@ import java.util.stream.Collectors;
 
 public class TestBaseMigrationManager {
 
+    /**
+     * Проверяет, что сама цепочка миграций не меняет данные.
+     * Если мигратор только перегоняет значение дальше, на выходе должен остаться исходный payload.
+     */
     @Test
     public void shouldKeepSourceDataWhenMigratorDoesNotTransformIt() throws MigrationException {
         BaseMigrationStore migrationStore =
@@ -29,6 +33,10 @@ public class TestBaseMigrationManager {
         Assert.assertEquals("A", result);
     }
 
+    /**
+     * Проверяет, что каждый следующий шаг получает результат предыдущего шага.
+     * Ловит баг, при котором все шаги вызывались с исходным значением.
+     */
     @Test
     public void shouldPassIntermediateMigrationResultToNextStep() throws MigrationException {
         BaseMigrationStore migrationStore =
@@ -45,6 +53,10 @@ public class TestBaseMigrationManager {
         Assert.assertEquals("A123", result);
     }
 
+    /**
+     * Собирает простой упорядоченный маршрут миграции для теста.
+     * Этого достаточно, чтобы проверить chaining без лишнего проектного окружения.
+     */
     private static class MigrationPointProviderStub implements MigrationPointProvider {
         private final List<MigrationPoint> migrationPoints;
 
@@ -73,6 +85,10 @@ public class TestBaseMigrationManager {
         }
     }
 
+    /**
+     * Хранит тестовый идентификатор шага, например TEST1 или TEST2.
+     * Нужен, чтобы было видно, какие шаги реально применились и в каком порядке.
+     */
     private static class TestMigrationSpec implements MigrationSpec<String> {
         private final String spec;
 
@@ -91,6 +107,10 @@ public class TestBaseMigrationManager {
         }
     }
 
+    /**
+     * Имитирует мигратор, который просто пропускает данные через сериализацию.
+     * Нужен, чтобы проверить поведение самого migration manager без дополнительных преобразований.
+     */
     private static class PassThroughMigrator extends AbstractMigrator {
 
         @Override
@@ -104,6 +124,10 @@ public class TestBaseMigrationManager {
         }
     }
 
+    /**
+     * Дописывает к payload номер текущего шага миграции.
+     * Так видно, получают ли поздние шаги накопленный результат или снова исходный input.
+     */
     private static class StepNumberAppendingMigrator implements Migrator {
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>dev.vality.geck</groupId>
     <artifactId>parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>pom</packaging>
 
     <name>Geck</name>

--- a/serializer/pom.xml
+++ b/serializer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.vality.geck</groupId>
         <artifactId>parent</artifactId>
-        <version>1.0.2</version>
+        <version>1.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/json/JsonProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/json/JsonProcessor.java
@@ -59,6 +59,9 @@ public class JsonProcessor implements StructProcessor<JsonNode> {
                 }
                 String arrCode = elements.next().textValue();
                 StructType arrType = StructType.valueOfKey(arrCode);
+                if (arrType == null) {
+                    throw new BadFormatException("Unknown type of node: " + arrCode + ". Must be on of them : " + StructType.LIST + ", " + StructType.SET + ", " + StructType.MAP);
+                }
                 int size = jsonNode.size() - 1;
                 switch (arrType) {
                     case LIST:
@@ -85,7 +88,7 @@ public class JsonProcessor implements StructProcessor<JsonNode> {
                         handler.endMap();
                         break;
                     default:
-                        new BadFormatException("Unknown type of node: " + arrType + ". Must be on of them : " + StructType.LIST + ", " + StructType.SET + ", " + StructType.MAP);
+                        throw new BadFormatException("Unknown type of node: " + arrType + ". Must be on of them : " + StructType.LIST + ", " + StructType.SET + ", " + StructType.MAP);
                 }
             }
         }

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessor.java
@@ -24,7 +24,7 @@ public class MockTBaseProcessor extends TBaseProcessor {
     private final ValueGenerator valueGenerator;
 
     private final Map<String, FieldHandler> fieldHandlers = new HashMap<>();
-    private final Set<Class<? extends TBase>> structTypesInProgress = new HashSet<>();
+    private final ThreadLocal<Set<Class<? extends TBase>>> structTypesInProgress = new ThreadLocal<>();
 
     public MockTBaseProcessor() {
         this(MockMode.ALL);
@@ -52,6 +52,20 @@ public class MockTBaseProcessor extends TBaseProcessor {
     public void addFieldHandler(FieldHandler handler, String... fieldNames) {
         for (String fieldName : fieldNames) {
             fieldHandlers.put(fieldName, handler);
+        }
+    }
+
+    @Override
+    public <R> R process(TBase value, StructHandler<R> handler) throws IOException {
+        structTypesInProgress.set(new HashSet<>());
+        try {
+            if (value == null) {
+                handler.nullValue();
+                return handler.getResult();
+            }
+            return super.process(value, handler);
+        } finally {
+            structTypesInProgress.remove();
         }
     }
 
@@ -132,7 +146,8 @@ public class MockTBaseProcessor extends TBaseProcessor {
 
     private void processStruct(StructMetaData structMetaData, StructHandler handler) throws IOException {
         Class<? extends TBase> structClass = structMetaData.getStructClass();
-        if (!structTypesInProgress.add(structClass)) {
+        Set<Class<? extends TBase>> currentStructTypes = currentStructTypes();
+        if (!currentStructTypes.add(structClass)) {
             throw new IllegalStateException(String.format(
                     "Recursive thrift type detected while generating mock for '%s'",
                     structClass.getName()
@@ -144,7 +159,7 @@ public class MockTBaseProcessor extends TBaseProcessor {
         } catch (InstantiationException | IllegalAccessException ex) {
             throw new IOException(ex);
         } finally {
-            structTypesInProgress.remove(structClass);
+            currentStructTypes.remove(structClass);
         }
     }
 
@@ -197,6 +212,14 @@ public class MockTBaseProcessor extends TBaseProcessor {
         }
         fieldHandler.handle(handler);
         return true;
+    }
+
+    private Set<Class<? extends TBase>> currentStructTypes() {
+        Set<Class<? extends TBase>> currentStructTypes = structTypesInProgress.get();
+        if (currentStructTypes == null) {
+            throw new IllegalStateException("Mock generation context is not initialized");
+        }
+        return currentStructTypes;
     }
 
 }

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessor.java
@@ -8,6 +8,8 @@ import org.apache.thrift.*;
 import org.apache.thrift.meta_data.*;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,6 +24,7 @@ public class MockTBaseProcessor extends TBaseProcessor {
     private ValueGenerator valueGenerator;
 
     private Map<String, FieldHandler> fieldHandlers = new HashMap<>();
+    private final Deque<Class<? extends TBase>> structPath = new ArrayDeque<>();
 
     public MockTBaseProcessor() {
         this(MockMode.ALL);
@@ -56,7 +59,7 @@ public class MockTBaseProcessor extends TBaseProcessor {
     protected void processUnsetField(TFieldIdEnum tFieldIdEnum, FieldMetaData fieldMetaData, StructHandler handler) throws IOException {
         if (needProcess(fieldMetaData)) {
             handler.name((byte) tFieldIdEnum.getThriftFieldId(), tFieldIdEnum.getFieldName());
-            if (fieldHandlers.containsKey(fieldMetaData.fieldName)) {
+            if (fieldHandlers.containsKey(tFieldIdEnum.getFieldName())) {
                 fieldHandlers.get(tFieldIdEnum.getFieldName()).handle(handler);
             } else {
                 processFieldValue(fieldMetaData.valueMetaData, handler);
@@ -70,7 +73,7 @@ public class MockTBaseProcessor extends TBaseProcessor {
         TFieldIdEnum tFieldIdEnum = valueGenerator.getField(tUnion);
         FieldMetaData fieldMetaData = fieldMetaDataMap.get(tFieldIdEnum);
         handler.name((byte) tFieldIdEnum.getThriftFieldId(), tFieldIdEnum.getFieldName());
-        if (fieldHandlers.containsKey(fieldMetaData.fieldName)) {
+        if (fieldHandlers.containsKey(tFieldIdEnum.getFieldName())) {
             fieldHandlers.get(tFieldIdEnum.getFieldName()).handle(handler);
         } else {
             processFieldValue(fieldMetaData.valueMetaData, handler);
@@ -130,11 +133,21 @@ public class MockTBaseProcessor extends TBaseProcessor {
     }
 
     private void processStruct(StructMetaData structMetaData, StructHandler handler) throws IOException {
+        Class<? extends TBase> structClass = structMetaData.getStructClass();
+        if (structPath.contains(structClass)) {
+            throw new IllegalStateException(String.format(
+                    "Recursive thrift type detected while generating mock for '%s'",
+                    structClass.getName()
+            ));
+        }
+        structPath.push(structClass);
         try {
-            TBase tBase = structMetaData.getStructClass().newInstance();
+            TBase tBase = structClass.newInstance();
             super.processStruct(tBase, handler);
         } catch (InstantiationException | IllegalAccessException ex) {
             throw new IOException(ex);
+        } finally {
+            structPath.pop();
         }
     }
 

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessor.java
@@ -8,10 +8,10 @@ import org.apache.thrift.*;
 import org.apache.thrift.meta_data.*;
 
 import java.io.IOException;
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class MockTBaseProcessor extends TBaseProcessor {
 
@@ -21,10 +21,10 @@ public class MockTBaseProcessor extends TBaseProcessor {
 
     private final int maxContainerSize;
 
-    private ValueGenerator valueGenerator;
+    private final ValueGenerator valueGenerator;
 
-    private Map<String, FieldHandler> fieldHandlers = new HashMap<>();
-    private final Deque<Class<? extends TBase>> structPath = new ArrayDeque<>();
+    private final Map<String, FieldHandler> fieldHandlers = new HashMap<>();
+    private final Set<Class<? extends TBase>> structTypesInProgress = new HashSet<>();
 
     public MockTBaseProcessor() {
         this(MockMode.ALL);
@@ -59,11 +59,10 @@ public class MockTBaseProcessor extends TBaseProcessor {
     protected void processUnsetField(TFieldIdEnum tFieldIdEnum, FieldMetaData fieldMetaData, StructHandler handler) throws IOException {
         if (needProcess(fieldMetaData)) {
             handler.name((byte) tFieldIdEnum.getThriftFieldId(), tFieldIdEnum.getFieldName());
-            if (fieldHandlers.containsKey(tFieldIdEnum.getFieldName())) {
-                fieldHandlers.get(tFieldIdEnum.getFieldName()).handle(handler);
-            } else {
-                processFieldValue(fieldMetaData.valueMetaData, handler);
+            if (handleField(tFieldIdEnum, handler)) {
+                return;
             }
+            processFieldValue(fieldMetaData.valueMetaData, handler);
         }
     }
 
@@ -73,11 +72,10 @@ public class MockTBaseProcessor extends TBaseProcessor {
         TFieldIdEnum tFieldIdEnum = valueGenerator.getField(tUnion);
         FieldMetaData fieldMetaData = fieldMetaDataMap.get(tFieldIdEnum);
         handler.name((byte) tFieldIdEnum.getThriftFieldId(), tFieldIdEnum.getFieldName());
-        if (fieldHandlers.containsKey(tFieldIdEnum.getFieldName())) {
-            fieldHandlers.get(tFieldIdEnum.getFieldName()).handle(handler);
-        } else {
-            processFieldValue(fieldMetaData.valueMetaData, handler);
+        if (handleField(tFieldIdEnum, handler)) {
+            return;
         }
+        processFieldValue(fieldMetaData.valueMetaData, handler);
     }
 
     protected void processFieldValue(FieldValueMetaData valueMetaData, StructHandler handler) throws IOException {
@@ -134,20 +132,19 @@ public class MockTBaseProcessor extends TBaseProcessor {
 
     private void processStruct(StructMetaData structMetaData, StructHandler handler) throws IOException {
         Class<? extends TBase> structClass = structMetaData.getStructClass();
-        if (structPath.contains(structClass)) {
+        if (!structTypesInProgress.add(structClass)) {
             throw new IllegalStateException(String.format(
                     "Recursive thrift type detected while generating mock for '%s'",
                     structClass.getName()
             ));
         }
-        structPath.push(structClass);
         try {
             TBase tBase = structClass.newInstance();
             super.processStruct(tBase, handler);
         } catch (InstantiationException | IllegalAccessException ex) {
             throw new IOException(ex);
         } finally {
-            structPath.pop();
+            structTypesInProgress.remove(structClass);
         }
     }
 
@@ -191,6 +188,15 @@ public class MockTBaseProcessor extends TBaseProcessor {
         return fieldMetaData.requirementType == TFieldRequirementType.REQUIRED
                 || (mode == MockMode.RANDOM && valueGenerator.getBoolean())
                 || mode == MockMode.ALL;
+    }
+
+    private boolean handleField(TFieldIdEnum field, StructHandler handler) throws IOException {
+        FieldHandler fieldHandler = fieldHandlers.get(field.getFieldName());
+        if (fieldHandler == null) {
+            return false;
+        }
+        fieldHandler.handle(handler);
+        return true;
     }
 
 }

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/object/ObjectProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/object/ObjectProcessor.java
@@ -96,7 +96,7 @@ public class ObjectProcessor implements StructProcessor<Object> {
                     if (named) {
                         processList(list, handler);
                     } else {
-                        if (list.size() > 0) {
+                        if (!list.isEmpty()) {
                             StructType lType = getType(String.valueOf(list.get(0)));
                             switch (lType) {
                                 case OTHER:
@@ -112,18 +112,16 @@ public class ObjectProcessor implements StructProcessor<Object> {
                 } else if (value instanceof String) {
                     handler.value(unescapeString((String) value));
                 } else if (value instanceof Number) {
+                    Number number = (Number) value;
                     if (value instanceof Double || value instanceof Float) {
-                        handler.value(((Number) value).doubleValue());
+                        handler.value(number.doubleValue());
                     } else {
-                        handler.value(((Number) value).longValue());
+                        handler.value(number.longValue());
                     }
                 } else if (value instanceof Boolean) {
-                    handler.value(((Boolean) value).booleanValue());
+                    handler.value((Boolean) value);
                 } else if (value instanceof ByteBuffer) {
-                    ByteBuffer duplicate = ((ByteBuffer) value).duplicate();
-                    byte[] bytes = new byte[duplicate.remaining()];
-                    duplicate.get(bytes);
-                    handler.value(bytes);
+                    handler.value(readBinary((ByteBuffer) value));
                 } else if (value == null) {
                     handler.nullValue();
                 } else {
@@ -182,5 +180,12 @@ public class ObjectProcessor implements StructProcessor<Object> {
         } else {
             return name;
         }
+    }
+
+    private byte[] readBinary(ByteBuffer buffer) {
+        ByteBuffer duplicate = buffer.duplicate();
+        byte[] bytes = new byte[duplicate.remaining()];
+        duplicate.get(bytes);
+        return bytes;
     }
 }

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/object/ObjectProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/object/ObjectProcessor.java
@@ -1,5 +1,6 @@
 package dev.vality.geck.serializer.kit.object;
 
+import dev.vality.geck.common.util.BinaryUtil;
 import dev.vality.geck.common.util.TypeUtil;
 import dev.vality.geck.serializer.StructHandler;
 import dev.vality.geck.serializer.StructProcessor;
@@ -121,7 +122,7 @@ public class ObjectProcessor implements StructProcessor<Object> {
                 } else if (value instanceof Boolean) {
                     handler.value((Boolean) value);
                 } else if (value instanceof ByteBuffer) {
-                    handler.value(readBinary((ByteBuffer) value));
+                    handler.value(BinaryUtil.toByteArray((ByteBuffer) value));
                 } else if (value == null) {
                     handler.nullValue();
                 } else {
@@ -182,10 +183,4 @@ public class ObjectProcessor implements StructProcessor<Object> {
         }
     }
 
-    private byte[] readBinary(ByteBuffer buffer) {
-        ByteBuffer currentRange = buffer.slice();
-        byte[] bytes = new byte[currentRange.remaining()];
-        currentRange.get(bytes);
-        return bytes;
-    }
 }

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/object/ObjectProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/object/ObjectProcessor.java
@@ -41,9 +41,13 @@ public class ObjectProcessor implements StructProcessor<Object> {
         handler.beginMap(mapList.size());
         Iterator it = mapList.iterator();
         if (!named) {
-            assert it.hasNext();
+            if (!it.hasNext()) {
+                throw new BadFormatException("Incorrect structure of map. First element should exist!");
+            }
             Object mapSign = it.next();
-            assert getType(String.valueOf(mapSign)) == StructType.MAP;
+            if (getType(String.valueOf(mapSign)) != StructType.MAP) {
+                throw new BadFormatException("Incorrect structure of map. First element should contain map marker!");
+            }
         }
         for (Object entry; it.hasNext(); ) {
             entry = it.next();
@@ -81,6 +85,7 @@ public class ObjectProcessor implements StructProcessor<Object> {
                 break;
             case SET:
                 processSet(TypeUtil.convertType(Collection.class, value), named, handler);
+                break;
             case OTHER:
                 if (value instanceof Map) {
                     processStruct((Map) value, handler);
@@ -115,7 +120,10 @@ public class ObjectProcessor implements StructProcessor<Object> {
                 } else if (value instanceof Boolean) {
                     handler.value(((Boolean) value).booleanValue());
                 } else if (value instanceof ByteBuffer) {
-                    handler.value(((ByteBuffer) value).array());
+                    ByteBuffer duplicate = ((ByteBuffer) value).duplicate();
+                    byte[] bytes = new byte[duplicate.remaining()];
+                    duplicate.get(bytes);
+                    handler.value(bytes);
                 } else if (value == null) {
                     handler.nullValue();
                 } else {

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/object/ObjectProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/object/ObjectProcessor.java
@@ -183,9 +183,9 @@ public class ObjectProcessor implements StructProcessor<Object> {
     }
 
     private byte[] readBinary(ByteBuffer buffer) {
-        ByteBuffer duplicate = buffer.duplicate();
-        byte[] bytes = new byte[duplicate.remaining()];
-        duplicate.get(bytes);
+        ByteBuffer currentRange = buffer.slice();
+        byte[] bytes = new byte[currentRange.remaining()];
+        currentRange.get(bytes);
         return bytes;
     }
 }

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessor.java
@@ -1,5 +1,6 @@
 package dev.vality.geck.serializer.kit.tbase;
 
+import dev.vality.geck.common.util.BinaryUtil;
 import dev.vality.geck.common.util.TBaseUtil;
 import dev.vality.geck.common.util.TypeUtil;
 import dev.vality.geck.serializer.StructHandler;
@@ -17,7 +18,6 @@ import java.util.*;
 public class TBaseProcessor implements StructProcessor<TBase> {
 
     private final boolean checkRequiredFields;
-    private final Set<TBase> structsInProgress = newIdentitySet();
 
     public TBaseProcessor() {
         this(true);
@@ -32,13 +32,17 @@ public class TBaseProcessor implements StructProcessor<TBase> {
         if (value == null) {
             handler.nullValue();
         } else {
-            processStruct(value, handler);
+            processStruct(value, handler, newIdentitySet());
         }
 
         return handler.getResult();
     }
 
     protected void processStruct(TBase value, StructHandler handler) throws IOException {
+        processStruct(value, handler, newIdentitySet());
+    }
+
+    protected void processStruct(TBase value, StructHandler handler, Set<TBase> structsInProgress) throws IOException {
         if (!structsInProgress.add(value)) {
             throw new IllegalStateException(String.format(
                     "Cyclic reference detected while processing thrift struct '%s'",
@@ -57,7 +61,8 @@ public class TBaseProcessor implements StructProcessor<TBase> {
                 if (union.isSet()) {
                     TFieldIdEnum tFieldIdEnum = union.getSetField();
                     handler.name((byte) tFieldIdEnum.getThriftFieldId(), tFieldIdEnum.getFieldName());
-                    process(union.getFieldValue(), fieldMetaDataMap.get(tFieldIdEnum).valueMetaData, handler);
+                    process(union.getFieldValue(), fieldMetaDataMap.get(tFieldIdEnum).valueMetaData, handler,
+                            structsInProgress);
                 } else {
                     processUnsetUnion(union, handler);
                 }
@@ -66,7 +71,8 @@ public class TBaseProcessor implements StructProcessor<TBase> {
                     FieldMetaData fieldMetaData = fieldMetaDataMap.get(tFieldIdEnum);
                     if (value.isSet(tFieldIdEnum)) {
                         handler.name((byte) tFieldIdEnum.getThriftFieldId(), tFieldIdEnum.getFieldName());
-                        process(value.getFieldValue(tFieldIdEnum), fieldMetaData.valueMetaData, handler);
+                        process(value.getFieldValue(tFieldIdEnum), fieldMetaData.valueMetaData, handler,
+                                structsInProgress);
                     } else {
                         processUnsetField(tFieldIdEnum, fieldMetaData, handler);
                     }
@@ -89,13 +95,17 @@ public class TBaseProcessor implements StructProcessor<TBase> {
         }
     }
 
-    private void process(Object object, FieldValueMetaData fieldValueMetaData, StructHandler handler) throws IOException {
+    private void process(
+            Object object,
+            FieldValueMetaData fieldValueMetaData,
+            StructHandler handler,
+            Set<TBase> structsInProgress) throws IOException {
         if (object == null) {
             handler.nullValue();
         } else if (object instanceof Optional<?> optional) {
             if (optional.isPresent()) {
                 Object value = optional.get();
-                process(value, fieldValueMetaData, handler);
+                process(value, fieldValueMetaData, handler, structsInProgress);
             } else {
                 handler.nullValue();
             }
@@ -131,7 +141,7 @@ public class TBaseProcessor implements StructProcessor<TBase> {
                     if (object instanceof byte[]) {
                         handler.value((byte[]) object);
                     } else if (object instanceof ByteBuffer) {
-                        handler.value(copyBinary((ByteBuffer) object));
+                        handler.value(BinaryUtil.toByteArray((ByteBuffer) object));
                     } else {
                         throw new IllegalStateException(String.format("Unknown binary type, type='%s'", object.getClass().getName()));
                     }
@@ -139,18 +149,18 @@ public class TBaseProcessor implements StructProcessor<TBase> {
                 case LIST:
                     List list = TypeUtil.convertType(List.class, object);
                     ListMetaData listMetaData = TypeUtil.convertType(ListMetaData.class, fieldValueMetaData);
-                    processList(list, listMetaData, handler);
+                    processList(list, listMetaData, handler, structsInProgress);
                     break;
                 case SET:
                     Set set = TypeUtil.convertType(Set.class, object);
                     SetMetaData setMetaData = TypeUtil.convertType(SetMetaData.class, fieldValueMetaData);
-                    processSet(set, setMetaData, handler);
+                    processSet(set, setMetaData, handler, structsInProgress);
                     break;
                 case MAP:
-                    processMap((Map) object, (MapMetaData) fieldValueMetaData, handler);
+                    processMap((Map) object, (MapMetaData) fieldValueMetaData, handler, structsInProgress);
                     break;
                 case STRUCT:
-                    processStruct((TBase) object, handler);
+                    processStruct((TBase) object, handler, structsInProgress);
                     break;
                 default:
                     throw new IllegalStateException(String.format("Type '%s' not found", type));
@@ -158,42 +168,51 @@ public class TBaseProcessor implements StructProcessor<TBase> {
         }
     }
 
-    private void processList(List list, ListMetaData listMetaData, StructHandler handler) throws IOException {
+    private void processList(
+            List list,
+            ListMetaData listMetaData,
+            StructHandler handler,
+            Set<TBase> structsInProgress) throws IOException {
         handler.beginList(list.size());
-        processCollection(list, listMetaData.getElementMetaData(), handler);
+        processCollection(list, listMetaData.getElementMetaData(), handler, structsInProgress);
         handler.endList();
     }
 
-    private void processSet(Set set, SetMetaData setMetaData, StructHandler handler) throws IOException {
+    private void processSet(
+            Set set,
+            SetMetaData setMetaData,
+            StructHandler handler,
+            Set<TBase> structsInProgress) throws IOException {
         handler.beginSet(set.size());
-        processCollection(set, setMetaData.getElementMetaData(), handler);
+        processCollection(set, setMetaData.getElementMetaData(), handler, structsInProgress);
         handler.endSet();
     }
 
-    private void processCollection(Collection collection, FieldValueMetaData valueMetaData, StructHandler handler) throws IOException {
+    private void processCollection(
+            Collection collection,
+            FieldValueMetaData valueMetaData,
+            StructHandler handler,
+            Set<TBase> structsInProgress) throws IOException {
         for (Object object : collection) {
-            process(object, valueMetaData, handler);
+            process(object, valueMetaData, handler, structsInProgress);
         }
     }
 
-    private void processMap(Map objectMap, MapMetaData metaData, StructHandler handler) throws IOException {
+    private void processMap(
+            Map objectMap,
+            MapMetaData metaData,
+            StructHandler handler,
+            Set<TBase> structsInProgress) throws IOException {
         handler.beginMap(objectMap.size());
         for (Map.Entry entry : (Set<Map.Entry>) objectMap.entrySet()) {
             handler.beginKey();
-            process(entry.getKey(), metaData.getKeyMetaData(), handler);
+            process(entry.getKey(), metaData.getKeyMetaData(), handler, structsInProgress);
             handler.endKey();
             handler.beginValue();
-            process(entry.getValue(), metaData.getValueMetaData(), handler);
+            process(entry.getValue(), metaData.getValueMetaData(), handler, structsInProgress);
             handler.endValue();
         }
         handler.endMap();
-    }
-
-    protected byte[] copyBinary(ByteBuffer buffer) {
-        ByteBuffer duplicate = buffer.duplicate();
-        byte[] bytes = new byte[duplicate.remaining()];
-        duplicate.get(bytes);
-        return bytes;
     }
 
     private static <T> Set<T> newIdentitySet() {

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessor.java
@@ -17,6 +17,7 @@ import java.util.*;
 public class TBaseProcessor implements StructProcessor<TBase> {
 
     private final boolean checkRequiredFields;
+    private final IdentityHashMap<TBase, Boolean> visitingStructs = new IdentityHashMap<>();
 
     public TBaseProcessor() {
         this(true);
@@ -38,34 +39,44 @@ public class TBaseProcessor implements StructProcessor<TBase> {
     }
 
     protected void processStruct(TBase value, StructHandler handler) throws IOException {
-        TFieldIdEnum[] tFieldIdEnums = value.getFields();
-        Map<TFieldIdEnum, FieldMetaData> fieldMetaDataMap = value.getFieldMetaData();
+        if (visitingStructs.put(value, Boolean.TRUE) != null) {
+            throw new IllegalStateException(String.format(
+                    "Cyclic reference detected while processing thrift struct '%s'",
+                    value.getClass().getName()
+            ));
+        }
+        try {
+            TFieldIdEnum[] tFieldIdEnums = value.getFields();
+            Map<TFieldIdEnum, FieldMetaData> fieldMetaDataMap = value.getFieldMetaData();
 
-        int size = TBaseUtil.getSetFieldsCount(value);
-        handler.beginStruct(size);
+            int size = TBaseUtil.getSetFieldsCount(value);
+            handler.beginStruct(size);
 
-        if (value instanceof TUnion) {
-            TUnion union = (TUnion) value;
-            if (union.isSet()) {
-                TFieldIdEnum tFieldIdEnum = union.getSetField();
-                handler.name((byte) tFieldIdEnum.getThriftFieldId(), tFieldIdEnum.getFieldName());
-                process(union.getFieldValue(), fieldMetaDataMap.get(tFieldIdEnum).valueMetaData, handler);
-            } else {
-                processUnsetUnion(union, handler);
-            }
-        } else {
-            for (TFieldIdEnum tFieldIdEnum : tFieldIdEnums) {
-                FieldMetaData fieldMetaData = fieldMetaDataMap.get(tFieldIdEnum);
-                if (value.isSet(tFieldIdEnum)) {
+            if (value instanceof TUnion) {
+                TUnion union = (TUnion) value;
+                if (union.isSet()) {
+                    TFieldIdEnum tFieldIdEnum = union.getSetField();
                     handler.name((byte) tFieldIdEnum.getThriftFieldId(), tFieldIdEnum.getFieldName());
-                    process(value.getFieldValue(tFieldIdEnum), fieldMetaData.valueMetaData, handler);
+                    process(union.getFieldValue(), fieldMetaDataMap.get(tFieldIdEnum).valueMetaData, handler);
                 } else {
-                    processUnsetField(tFieldIdEnum, fieldMetaData, handler);
+                    processUnsetUnion(union, handler);
+                }
+            } else {
+                for (TFieldIdEnum tFieldIdEnum : tFieldIdEnums) {
+                    FieldMetaData fieldMetaData = fieldMetaDataMap.get(tFieldIdEnum);
+                    if (value.isSet(tFieldIdEnum)) {
+                        handler.name((byte) tFieldIdEnum.getThriftFieldId(), tFieldIdEnum.getFieldName());
+                        process(value.getFieldValue(tFieldIdEnum), fieldMetaData.valueMetaData, handler);
+                    } else {
+                        processUnsetField(tFieldIdEnum, fieldMetaData, handler);
+                    }
                 }
             }
-        }
 
-        handler.endStruct();
+            handler.endStruct();
+        } finally {
+            visitingStructs.remove(value);
+        }
     }
 
     protected void processUnsetUnion(TUnion tUnion, StructHandler handler) throws IOException {
@@ -120,7 +131,7 @@ public class TBaseProcessor implements StructProcessor<TBase> {
                     if (object instanceof byte[]) {
                         handler.value((byte[]) object);
                     } else if (object instanceof ByteBuffer) {
-                        handler.value(((ByteBuffer) object).array());
+                        handler.value(copyBinary((ByteBuffer) object));
                     } else {
                         throw new IllegalStateException(String.format("Unknown binary type, type='%s'", object.getClass().getName()));
                     }
@@ -178,5 +189,11 @@ public class TBaseProcessor implements StructProcessor<TBase> {
         handler.endMap();
     }
 
+    protected byte[] copyBinary(ByteBuffer buffer) {
+        ByteBuffer duplicate = buffer.duplicate();
+        byte[] bytes = new byte[duplicate.remaining()];
+        duplicate.get(bytes);
+        return bytes;
+    }
 
 }

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessor.java
@@ -17,7 +17,7 @@ import java.util.*;
 public class TBaseProcessor implements StructProcessor<TBase> {
 
     private final boolean checkRequiredFields;
-    private final IdentityHashMap<TBase, Boolean> visitingStructs = new IdentityHashMap<>();
+    private final Set<TBase> structsInProgress = newIdentitySet();
 
     public TBaseProcessor() {
         this(true);
@@ -39,7 +39,7 @@ public class TBaseProcessor implements StructProcessor<TBase> {
     }
 
     protected void processStruct(TBase value, StructHandler handler) throws IOException {
-        if (visitingStructs.put(value, Boolean.TRUE) != null) {
+        if (!structsInProgress.add(value)) {
             throw new IllegalStateException(String.format(
                     "Cyclic reference detected while processing thrift struct '%s'",
                     value.getClass().getName()
@@ -75,7 +75,7 @@ public class TBaseProcessor implements StructProcessor<TBase> {
 
             handler.endStruct();
         } finally {
-            visitingStructs.remove(value);
+            structsInProgress.remove(value);
         }
     }
 
@@ -194,6 +194,10 @@ public class TBaseProcessor implements StructProcessor<TBase> {
         byte[] bytes = new byte[duplicate.remaining()];
         duplicate.get(bytes);
         return bytes;
+    }
+
+    private static <T> Set<T> newIdentitySet() {
+        return Collections.newSetFromMap(new IdentityHashMap<>());
     }
 
 }

--- a/serializer/src/main/java/dev/vality/geck/serializer/kit/xml/XMLProcessor.java
+++ b/serializer/src/main/java/dev/vality/geck/serializer/kit/xml/XMLProcessor.java
@@ -88,7 +88,7 @@ public class XMLProcessor implements StructProcessor<DOMResult> {
                     handler.endValue();
                     break;
                 default:
-                    new BadFormatException("Unknown type of node: "+type+". Must be on of them : "+ Arrays.toString(StructType.values()));
+                    throw new BadFormatException("Unknown type of node: "+type+". Must be on of them : "+ Arrays.toString(StructType.values()));
             }
         }
     }

--- a/serializer/src/test/java/dev/vality/geck/serializer/domain/RecursiveStruct.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/domain/RecursiveStruct.java
@@ -1,0 +1,131 @@
+package dev.vality.geck.serializer.domain;
+
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.TFieldIdEnum;
+import org.apache.thrift.TFieldRequirementType;
+import org.apache.thrift.meta_data.FieldMetaData;
+import org.apache.thrift.meta_data.StructMetaData;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TType;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+public class RecursiveStruct implements TBase<RecursiveStruct, RecursiveStruct._Fields> {
+
+    private static final Map<_Fields, FieldMetaData> META_DATA_MAP;
+
+    static {
+        Map<_Fields, FieldMetaData> metaData = new EnumMap<>(_Fields.class);
+        metaData.put(_Fields.NEXT, new FieldMetaData(
+                "next",
+                TFieldRequirementType.REQUIRED,
+                new StructMetaData(TType.STRUCT, RecursiveStruct.class)
+        ));
+        META_DATA_MAP = Collections.unmodifiableMap(metaData);
+        FieldMetaData.addStructMetaDataMap(RecursiveStruct.class, META_DATA_MAP);
+    }
+
+    private RecursiveStruct next;
+
+    @Override
+    public void clear() {
+        next = null;
+    }
+
+    @Override
+    public RecursiveStruct deepCopy() {
+        RecursiveStruct copy = new RecursiveStruct();
+        copy.next = next;
+        return copy;
+    }
+
+    public RecursiveStruct setNext(RecursiveStruct next) {
+        this.next = next;
+        return this;
+    }
+
+    public RecursiveStruct getNext() {
+        return next;
+    }
+
+    @Override
+    public void setFieldValue(_Fields field, Object value) {
+        if (field == _Fields.NEXT) {
+            next = (RecursiveStruct) value;
+            return;
+        }
+        throw new IllegalArgumentException("Unknown field: " + field);
+    }
+
+    @Override
+    public Object getFieldValue(_Fields field) {
+        if (field == _Fields.NEXT) {
+            return next;
+        }
+        throw new IllegalArgumentException("Unknown field: " + field);
+    }
+
+    @Override
+    public boolean isSet(_Fields field) {
+        return field == _Fields.NEXT && next != null;
+    }
+
+    @Override
+    public _Fields fieldForId(int fieldId) {
+        return _Fields.findByThriftId(fieldId);
+    }
+
+    @Override
+    public int compareTo(RecursiveStruct other) {
+        return 0;
+    }
+
+    @Override
+    public void read(TProtocol iprot) throws TException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void write(TProtocol oprot) throws TException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public _Fields[] getFields() {
+        return _Fields.values();
+    }
+
+    @Override
+    public Map<_Fields, FieldMetaData> getFieldMetaData() {
+        return META_DATA_MAP;
+    }
+
+    public enum _Fields implements TFieldIdEnum {
+        NEXT((short) 1, "next");
+
+        private final short thriftId;
+        private final String fieldName;
+
+        _Fields(short thriftId, String fieldName) {
+            this.thriftId = thriftId;
+            this.fieldName = fieldName;
+        }
+
+        @Override
+        public short getThriftFieldId() {
+            return thriftId;
+        }
+
+        @Override
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        public static _Fields findByThriftId(int fieldId) {
+            return fieldId == 1 ? NEXT : null;
+        }
+    }
+}

--- a/serializer/src/test/java/dev/vality/geck/serializer/domain/RecursiveStruct.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/domain/RecursiveStruct.java
@@ -13,6 +13,10 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 
+/**
+ * Минимальная рекурсивная thrift-подобная структура только для тестов.
+ * Нужна, чтобы собрать цикл в ссылках без зависимости от сгенерированных моделей проекта.
+ */
 public class RecursiveStruct implements TBase<RecursiveStruct, RecursiveStruct._Fields> {
 
     private static final Map<_Fields, FieldMetaData> META_DATA_MAP;
@@ -103,6 +107,10 @@ public class RecursiveStruct implements TBase<RecursiveStruct, RecursiveStruct._
         return META_DATA_MAP;
     }
 
+    /**
+     * Описывает единственное рекурсивное поле тестовой структуры.
+     * TBase требует такой enum, чтобы выдавать id и имя поля так же, как обычный thrift-класс.
+     */
     public enum _Fields implements TFieldIdEnum {
         NEXT((short) 1, "next");
 

--- a/serializer/src/test/java/dev/vality/geck/serializer/handler/BinaryCapturingHandler.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/handler/BinaryCapturingHandler.java
@@ -1,0 +1,18 @@
+package dev.vality.geck.serializer.handler;
+
+public class BinaryCapturingHandler extends HandlerStub {
+
+    private byte[] binaryValue;
+
+    @Override
+    public void value(byte[] value) {
+        if (binaryValue == null) {
+            binaryValue = value;
+        }
+    }
+
+    @Override
+    public byte[] getResult() {
+        return binaryValue;
+    }
+}

--- a/serializer/src/test/java/dev/vality/geck/serializer/handler/BinaryCapturingHandler.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/handler/BinaryCapturingHandler.java
@@ -1,5 +1,9 @@
 package dev.vality.geck.serializer.handler;
 
+/**
+ * Тестовый handler, который запоминает первое бинарное значение.
+ * Нужен, чтобы проверить, какие байты процессор реально отдал в результат.
+ */
 public class BinaryCapturingHandler extends HandlerStub {
 
     private byte[] binaryValue;

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/json/JsonTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/json/JsonTest.java
@@ -1,7 +1,10 @@
 package dev.vality.geck.serializer.kit.json;
 
 import com.rbkmoney.damsel.v130.payment_processing.InvoicePaymentStarted;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import dev.vality.geck.serializer.GeckTestUtil;
+import dev.vality.geck.serializer.exception.BadFormatException;
+import dev.vality.geck.serializer.handler.HandlerStub;
 import dev.vality.geck.serializer.kit.mock.FixedValueGenerator;
 import dev.vality.geck.serializer.kit.mock.MockMode;
 import dev.vality.geck.serializer.kit.mock.MockTBaseProcessor;
@@ -14,6 +17,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class JsonTest {
 
@@ -59,5 +64,14 @@ public class JsonTest {
         JsonHandler handler = JsonHandler.newPrettyJsonInstance();
         String json1 = new TBaseProcessor().process(testObject, handler).toString();
         System.out.println(json1);
+    }
+
+    @Test
+    public void unknownArrayTypeShouldFailFast() {
+        assertThatThrownBy(() -> new JsonProcessor().process(
+                JsonNodeFactory.instance.arrayNode().add("unsupported"),
+                new HandlerStub()))
+                .isInstanceOf(BadFormatException.class)
+                .hasMessageContaining("Unknown type of node: unsupported");
     }
 }

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/json/JsonTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/json/JsonTest.java
@@ -1,8 +1,9 @@
 package dev.vality.geck.serializer.kit.json;
 
-import com.rbkmoney.damsel.v130.payment_processing.InvoicePaymentStarted;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.rbkmoney.damsel.v130.payment_processing.InvoicePaymentStarted;
 import dev.vality.geck.serializer.GeckTestUtil;
+import dev.vality.geck.serializer.domain.TestObject;
 import dev.vality.geck.serializer.exception.BadFormatException;
 import dev.vality.geck.serializer.handler.HandlerStub;
 import dev.vality.geck.serializer.kit.mock.FixedValueGenerator;
@@ -12,7 +13,6 @@ import dev.vality.geck.serializer.kit.msgpack.MsgPackHandler;
 import dev.vality.geck.serializer.kit.msgpack.MsgPackProcessor;
 import dev.vality.geck.serializer.kit.tbase.TBaseHandler;
 import dev.vality.geck.serializer.kit.tbase.TBaseProcessor;
-import dev.vality.geck.serializer.domain.TestObject;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -66,6 +66,10 @@ public class JsonTest {
         System.out.println(json1);
     }
 
+    /**
+     * Проверяет, что JSON с неподдерживаемым маркером массива падает сразу.
+     * Без этого парсер уходил дальше с некорректным типом узла и ломался менее явно.
+     */
     @Test
     public void unknownArrayTypeShouldFailFast() {
         assertThatThrownBy(() -> new JsonProcessor().process(

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessorTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessorTest.java
@@ -64,6 +64,10 @@ public class MockTBaseProcessorTest {
         assertTrue(hasExpectedFields(result, false));
     }
 
+    /**
+     * Проверяет, что mock-генерация останавливается на рекурсивном thrift-типе.
+     * Без этой защиты генератор продолжал создавать вложенные объекты, пока не заканчивался стек.
+     */
     @Test
     public void recursiveSchemaShouldFailFastInsteadOfInfiniteMockGeneration() {
         assertThatThrownBy(() -> new MockTBaseProcessor(MockMode.ALL)

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessorTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessorTest.java
@@ -4,19 +4,28 @@ import dev.vality.geck.serializer.domain.BinaryTest;
 import dev.vality.geck.serializer.domain.TestObject;
 import dev.vality.geck.serializer.kit.tbase.TBaseHandler;
 import dev.vality.geck.serializer.kit.tbase.ThriftType;
+import org.apache.thrift.TException;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TFieldIdEnum;
 import org.apache.thrift.TFieldRequirementType;
 import org.apache.thrift.TUnion;
+import org.apache.thrift.meta_data.StructMetaData;
 import org.apache.thrift.meta_data.FieldMetaData;
+import org.apache.thrift.protocol.TField;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TStruct;
+import org.apache.thrift.protocol.TType;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.Map;
 
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.TestCase.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MockTBaseProcessorTest {
 
@@ -62,6 +71,14 @@ public class MockTBaseProcessorTest {
         assertTrue(checkFields(testObject, false));
     }
 
+    @Test
+    public void recursiveSchemaShouldFailFastInsteadOfInfiniteMockGeneration() {
+        assertThatThrownBy(() -> new MockTBaseProcessor(MockMode.ALL)
+                .process(new RecursiveStruct(), new TBaseHandler<>(RecursiveStruct.class)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Recursive thrift type detected");
+    }
+
 
     public boolean checkFields(TBase tBase, boolean requiredOnly) {
         Map<TFieldIdEnum, FieldMetaData> fieldMetaDataMap = tBase.getFieldMetaData();
@@ -87,6 +104,128 @@ public class MockTBaseProcessorTest {
 
         }
         return check;
+    }
+
+    public static class RecursiveStruct implements TBase<RecursiveStruct, RecursiveStruct._Fields> {
+        private static final TStruct STRUCT_DESC = new TStruct("RecursiveStruct");
+        private static final TField NEXT_FIELD_DESC = new TField("next", TType.STRUCT, (short) 1);
+        private static final Map<_Fields, FieldMetaData> META_DATA_MAP;
+
+        static {
+            Map<_Fields, FieldMetaData> metaData = new EnumMap<>(_Fields.class);
+            metaData.put(_Fields.NEXT, new FieldMetaData(
+                    "next",
+                    TFieldRequirementType.REQUIRED,
+                    new StructMetaData(TType.STRUCT, RecursiveStruct.class)
+            ));
+            META_DATA_MAP = Collections.unmodifiableMap(metaData);
+            FieldMetaData.addStructMetaDataMap(RecursiveStruct.class, META_DATA_MAP);
+        }
+
+        public RecursiveStruct next;
+
+        @Override
+        public void clear() {
+            next = null;
+        }
+
+        @Override
+        public RecursiveStruct deepCopy() {
+            RecursiveStruct copy = new RecursiveStruct();
+            copy.next = next;
+            return copy;
+        }
+
+        @Override
+        public void setFieldValue(_Fields field, Object value) {
+            if (field == _Fields.NEXT) {
+                next = (RecursiveStruct) value;
+            }
+        }
+
+        @Override
+        public Object getFieldValue(_Fields field) {
+            if (field == _Fields.NEXT) {
+                return next;
+            }
+            throw new IllegalArgumentException("Unknown field: " + field);
+        }
+
+        @Override
+        public boolean isSet(_Fields field) {
+            return field == _Fields.NEXT && next != null;
+        }
+
+        @Override
+        public _Fields fieldForId(int fieldId) {
+            return _Fields.findByThriftId(fieldId);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(this);
+        }
+
+        @Override
+        public int compareTo(RecursiveStruct other) {
+            return 0;
+        }
+
+        @Override
+        public void read(TProtocol iprot) throws TException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void write(TProtocol oprot) throws TException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String toString() {
+            return STRUCT_DESC.name;
+        }
+
+        @Override
+        public _Fields[] getFields() {
+            return _Fields.values();
+        }
+
+        @Override
+        public Map<_Fields, FieldMetaData> getFieldMetaData() {
+            return META_DATA_MAP;
+        }
+
+        public enum _Fields implements TFieldIdEnum {
+            NEXT((short) 1, "next");
+
+            private final short thriftId;
+            private final String fieldName;
+
+            _Fields(short thriftId, String fieldName) {
+                this.thriftId = thriftId;
+                this.fieldName = fieldName;
+            }
+
+            @Override
+            public short getThriftFieldId() {
+                return thriftId;
+            }
+
+            @Override
+            public String getFieldName() {
+                return fieldName;
+            }
+
+            public static _Fields findByThriftId(int fieldId) {
+                return fieldId == 1 ? NEXT : null;
+            }
+        }
     }
 
 }

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessorTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/mock/MockTBaseProcessorTest.java
@@ -1,26 +1,19 @@
 package dev.vality.geck.serializer.kit.mock;
 
 import dev.vality.geck.serializer.domain.BinaryTest;
+import dev.vality.geck.serializer.domain.RecursiveStruct;
 import dev.vality.geck.serializer.domain.TestObject;
 import dev.vality.geck.serializer.kit.tbase.TBaseHandler;
 import dev.vality.geck.serializer.kit.tbase.ThriftType;
-import org.apache.thrift.TException;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TFieldIdEnum;
 import org.apache.thrift.TFieldRequirementType;
 import org.apache.thrift.TUnion;
-import org.apache.thrift.meta_data.StructMetaData;
 import org.apache.thrift.meta_data.FieldMetaData;
-import org.apache.thrift.protocol.TField;
-import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.protocol.TStruct;
-import org.apache.thrift.protocol.TType;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.EnumMap;
 import java.util.Map;
 
 import static junit.framework.Assert.assertNotNull;
@@ -31,25 +24,25 @@ public class MockTBaseProcessorTest {
 
     @Test
     public void requiredFieldsOnlyTest() throws IOException {
-        TestObject testObject = new TestObject();
-        testObject = new MockTBaseProcessor(MockMode.REQUIRED_ONLY).process(testObject, new TBaseHandler<>(TestObject.class));
-        assertTrue(checkFields(testObject, true));
-        assertFalse(checkFields(testObject, false));
+        TestObject source = new TestObject();
+        TestObject result = new MockTBaseProcessor(MockMode.REQUIRED_ONLY).process(source, new TBaseHandler<>(TestObject.class));
+        assertTrue(hasExpectedFields(result, true));
+        assertFalse(hasExpectedFields(result, false));
     }
 
     @Test
     public void binaryTest() throws IOException {
-        BinaryTest binaryTest = new BinaryTest();
-        binaryTest = new MockTBaseProcessor(MockMode.REQUIRED_ONLY)
-                .process(binaryTest, new TBaseHandler<>(BinaryTest.class));
-        assertNotNull(binaryTest.getData());
-        assertNotNull(binaryTest.getDataInList());
-        binaryTest.getDataInList().stream().forEach(Assert::assertNotNull);
-        assertNotNull(binaryTest.getDataInSet());
-        binaryTest.getDataInSet().stream().forEach(Assert::assertNotNull);
-        assertNotNull(binaryTest.getDataInMap());
-        binaryTest.getDataInMap().keySet().stream().forEach(Assert::assertNotNull);
-        binaryTest.getDataInMap().values().stream().forEach(Assert::assertNotNull);
+        BinaryTest source = new BinaryTest();
+        BinaryTest result = new MockTBaseProcessor(MockMode.REQUIRED_ONLY)
+                .process(source, new TBaseHandler<>(BinaryTest.class));
+        assertNotNull(result.getData());
+        assertNotNull(result.getDataInList());
+        result.getDataInList().forEach(Assert::assertNotNull);
+        assertNotNull(result.getDataInSet());
+        result.getDataInSet().forEach(Assert::assertNotNull);
+        assertNotNull(result.getDataInMap());
+        result.getDataInMap().keySet().forEach(Assert::assertNotNull);
+        result.getDataInMap().values().forEach(Assert::assertNotNull);
     }
 
     @Test
@@ -58,17 +51,17 @@ public class MockTBaseProcessorTest {
 
         MockTBaseProcessor processor = new MockTBaseProcessor();
         processor.addFieldHandler(handler -> handler.value(testValue), "description", "another_string");
-        TestObject testObject = new TestObject();
-        testObject = processor.process(testObject, new TBaseHandler<>(TestObject.class));
-        assertEquals(testValue, testObject.getDescription());
-        assertEquals(testValue, testObject.getAnotherString());
+        TestObject source = new TestObject();
+        TestObject result = processor.process(source, new TBaseHandler<>(TestObject.class));
+        assertEquals(testValue, result.getDescription());
+        assertEquals(testValue, result.getAnotherString());
     }
 
     @Test
     public void allFieldsTest() throws IOException {
-        TestObject testObject = new TestObject();
-        testObject = new MockTBaseProcessor(MockMode.ALL).process(testObject, new TBaseHandler<>(TestObject.class));
-        assertTrue(checkFields(testObject, false));
+        TestObject source = new TestObject();
+        TestObject result = new MockTBaseProcessor(MockMode.ALL).process(source, new TBaseHandler<>(TestObject.class));
+        assertTrue(hasExpectedFields(result, false));
     }
 
     @Test
@@ -79,153 +72,29 @@ public class MockTBaseProcessorTest {
                 .hasMessageContaining("Recursive thrift type detected");
     }
 
-
-    public boolean checkFields(TBase tBase, boolean requiredOnly) {
+    private static boolean hasExpectedFields(TBase tBase, boolean requiredOnly) {
         Map<TFieldIdEnum, FieldMetaData> fieldMetaDataMap = tBase.getFieldMetaData();
-        boolean check = true;
+        boolean fieldsAreSet = true;
         if (tBase instanceof TUnion) {
             TUnion tUnion = (TUnion) tBase;
-            check &= tUnion.isSet();
+            fieldsAreSet &= tUnion.isSet();
             FieldMetaData fieldMetaData = fieldMetaDataMap.get(tUnion.getSetField());
             if (ThriftType.findByMetaData(fieldMetaData.valueMetaData) == ThriftType.STRUCT) {
-                check &= checkFields((TBase) tUnion.getFieldValue(), requiredOnly);
+                fieldsAreSet &= hasExpectedFields((TBase) tUnion.getFieldValue(), requiredOnly);
             }
         } else {
             for (TFieldIdEnum tFieldIdEnum : tBase.getFields()) {
                 FieldMetaData fieldMetaData = fieldMetaDataMap.get(tFieldIdEnum);
                 if (fieldMetaData.requirementType == TFieldRequirementType.REQUIRED
                         || !requiredOnly) {
-                    check &= tBase.isSet(tFieldIdEnum);
+                    fieldsAreSet &= tBase.isSet(tFieldIdEnum);
                     if (ThriftType.findByMetaData(fieldMetaData.valueMetaData) == ThriftType.STRUCT) {
-                        check &= checkFields((TBase) tBase.getFieldValue(tFieldIdEnum), requiredOnly);
+                        fieldsAreSet &= hasExpectedFields((TBase) tBase.getFieldValue(tFieldIdEnum), requiredOnly);
                     }
                 }
             }
 
         }
-        return check;
+        return fieldsAreSet;
     }
-
-    public static class RecursiveStruct implements TBase<RecursiveStruct, RecursiveStruct._Fields> {
-        private static final TStruct STRUCT_DESC = new TStruct("RecursiveStruct");
-        private static final TField NEXT_FIELD_DESC = new TField("next", TType.STRUCT, (short) 1);
-        private static final Map<_Fields, FieldMetaData> META_DATA_MAP;
-
-        static {
-            Map<_Fields, FieldMetaData> metaData = new EnumMap<>(_Fields.class);
-            metaData.put(_Fields.NEXT, new FieldMetaData(
-                    "next",
-                    TFieldRequirementType.REQUIRED,
-                    new StructMetaData(TType.STRUCT, RecursiveStruct.class)
-            ));
-            META_DATA_MAP = Collections.unmodifiableMap(metaData);
-            FieldMetaData.addStructMetaDataMap(RecursiveStruct.class, META_DATA_MAP);
-        }
-
-        public RecursiveStruct next;
-
-        @Override
-        public void clear() {
-            next = null;
-        }
-
-        @Override
-        public RecursiveStruct deepCopy() {
-            RecursiveStruct copy = new RecursiveStruct();
-            copy.next = next;
-            return copy;
-        }
-
-        @Override
-        public void setFieldValue(_Fields field, Object value) {
-            if (field == _Fields.NEXT) {
-                next = (RecursiveStruct) value;
-            }
-        }
-
-        @Override
-        public Object getFieldValue(_Fields field) {
-            if (field == _Fields.NEXT) {
-                return next;
-            }
-            throw new IllegalArgumentException("Unknown field: " + field);
-        }
-
-        @Override
-        public boolean isSet(_Fields field) {
-            return field == _Fields.NEXT && next != null;
-        }
-
-        @Override
-        public _Fields fieldForId(int fieldId) {
-            return _Fields.findByThriftId(fieldId);
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            return this == other;
-        }
-
-        @Override
-        public int hashCode() {
-            return System.identityHashCode(this);
-        }
-
-        @Override
-        public int compareTo(RecursiveStruct other) {
-            return 0;
-        }
-
-        @Override
-        public void read(TProtocol iprot) throws TException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void write(TProtocol oprot) throws TException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public String toString() {
-            return STRUCT_DESC.name;
-        }
-
-        @Override
-        public _Fields[] getFields() {
-            return _Fields.values();
-        }
-
-        @Override
-        public Map<_Fields, FieldMetaData> getFieldMetaData() {
-            return META_DATA_MAP;
-        }
-
-        public enum _Fields implements TFieldIdEnum {
-            NEXT((short) 1, "next");
-
-            private final short thriftId;
-            private final String fieldName;
-
-            _Fields(short thriftId, String fieldName) {
-                this.thriftId = thriftId;
-                this.fieldName = fieldName;
-            }
-
-            @Override
-            public short getThriftFieldId() {
-                return thriftId;
-            }
-
-            @Override
-            public String getFieldName() {
-                return fieldName;
-            }
-
-            public static _Fields findByThriftId(int fieldId) {
-                return fieldId == 1 ? NEXT : null;
-            }
-        }
-    }
-
 }

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/object/ObjectProcessorTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/object/ObjectProcessorTest.java
@@ -11,6 +11,10 @@ import java.io.IOException;
 
 public class ObjectProcessorTest {
 
+    /**
+     * Проверяет, что set не меняется после сериализации и обратного чтения.
+     * Ловит баг, при котором после обработки set код проваливался в следующую ветку switch.
+     */
     @Test
     public void shouldRoundTripSetsWithoutFallingThroughToOtherBranch() throws IOException {
         SetTest source = new MockTBaseProcessor().process(new SetTest(), new TBaseHandler<>(SetTest.class));

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/object/ObjectProcessorTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/object/ObjectProcessorTest.java
@@ -1,0 +1,23 @@
+package dev.vality.geck.serializer.kit.object;
+
+import dev.vality.geck.serializer.domain.SetTest;
+import dev.vality.geck.serializer.kit.mock.MockTBaseProcessor;
+import dev.vality.geck.serializer.kit.tbase.TBaseHandler;
+import dev.vality.geck.serializer.kit.tbase.TBaseProcessor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class ObjectProcessorTest {
+
+    @Test
+    public void shouldRoundTripSetsWithoutFallingThroughToOtherBranch() throws IOException {
+        SetTest source = new MockTBaseProcessor().process(new SetTest(), new TBaseHandler<>(SetTest.class));
+
+        Object encoded = new TBaseProcessor().process(source, new ObjectHandler());
+        SetTest restored = new ObjectProcessor().process(encoded, new TBaseHandler<>(SetTest.class));
+
+        Assert.assertEquals(source, restored);
+    }
+}

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessorTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessorTest.java
@@ -73,6 +73,10 @@ public class TBaseProcessorTest {
                 .hasMessage("Unknown binary type, type='java.lang.Integer'");
     }
 
+    /**
+     * Проверяет, что бинарные данные берутся только из активного диапазона ByteBuffer.
+     * Ловит случай, когда сериализация читала весь backing array и подтягивала лишние байты.
+     */
     @Test
     public void binaryByteBufferShouldRespectPositionAndLimit() throws IOException {
         BinaryTest binaryTest = new BinaryTest();
@@ -91,6 +95,10 @@ public class TBaseProcessorTest {
         Assert.assertArrayEquals(new byte[]{1, 2}, handler.getResult());
     }
 
+    /**
+     * Проверяет, что циклический граф объектов падает с понятной ошибкой, а не со stack overflow.
+     * Процессор умеет сериализовать дерево, но должен остановиться на петле в ссылках.
+     */
     @Test
     public void cyclicThriftGraphShouldFailFastInsteadOfStackOverflow() {
         RecursiveStruct first = new RecursiveStruct();

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessorTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessorTest.java
@@ -3,11 +3,22 @@ package dev.vality.geck.serializer.kit.tbase;
 import dev.vality.geck.serializer.domain.*;
 import dev.vality.geck.serializer.handler.HandlerStub;
 import dev.vality.geck.serializer.kit.mock.MockTBaseProcessor;
+import dev.vality.geck.serializer.StructHandler;
 import org.junit.Assert;
 import org.junit.Test;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TFieldIdEnum;
+import org.apache.thrift.TFieldRequirementType;
+import org.apache.thrift.meta_data.FieldMetaData;
+import org.apache.thrift.meta_data.StructMetaData;
+import org.apache.thrift.protocol.TType;
+import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
 import java.util.List;
 
 import static dev.vality.geck.serializer.GeckTestUtil.getTestObject;
@@ -68,6 +79,152 @@ public class TBaseProcessorTest {
         assertThatThrownBy(() -> new TBaseProcessor(false)
                 .process(binaryTest, new TBaseHandler(BinaryTest.class, TBaseHandler.Mode.PREFER_NAME, false)))
                 .hasMessage("Unknown binary type, type='java.lang.Integer'");
+    }
+
+    @Test
+    public void binaryByteBufferShouldRespectPositionAndLimit() throws IOException {
+        BinaryTest binaryTest = new BinaryTest();
+        ByteBuffer buffer = ByteBuffer.wrap(new byte[]{9, 1, 2, 8});
+        buffer.position(1);
+        buffer.limit(3);
+
+        binaryTest.setData(buffer);
+        binaryTest.setDataInList(Collections.emptyList());
+        binaryTest.setDataInSet(Collections.emptySet());
+        binaryTest.setDataInMap(Collections.emptyMap());
+
+        BinaryCapturingHandler handler = new BinaryCapturingHandler();
+        new TBaseProcessor().process(binaryTest, handler);
+
+        Assert.assertArrayEquals(new byte[]{1, 2}, handler.binaryValue);
+    }
+
+    @Test
+    public void cyclicThriftGraphShouldFailFastInsteadOfStackOverflow() {
+        TBase first = Mockito.mock(TBase.class);
+        TBase second = Mockito.mock(TBase.class);
+        TFieldIdEnum firstField = mockStructField((short) 1, "next");
+        TFieldIdEnum secondField = mockStructField((short) 1, "next");
+
+        Mockito.when(first.getFields()).thenReturn(new TFieldIdEnum[]{firstField});
+        Mockito.when(first.getFieldMetaData()).thenReturn(singleStructFieldMeta(firstField, "next"));
+        Mockito.when(first.isSet(firstField)).thenReturn(true);
+        Mockito.when(first.getFieldValue(firstField)).thenReturn(second);
+
+        Mockito.when(second.getFields()).thenReturn(new TFieldIdEnum[]{secondField});
+        Mockito.when(second.getFieldMetaData()).thenReturn(singleStructFieldMeta(secondField, "next"));
+        Mockito.when(second.isSet(secondField)).thenReturn(true);
+        Mockito.when(second.getFieldValue(secondField)).thenReturn(first);
+
+        assertThatThrownBy(() -> new TBaseProcessor().process(first, new HandlerStub()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Cyclic reference detected");
+    }
+
+    private static TFieldIdEnum mockStructField(short id, String name) {
+        TFieldIdEnum field = Mockito.mock(TFieldIdEnum.class);
+        Mockito.when(field.getThriftFieldId()).thenReturn(id);
+        Mockito.when(field.getFieldName()).thenReturn(name);
+        return field;
+    }
+
+    private static Map<TFieldIdEnum, FieldMetaData> singleStructFieldMeta(TFieldIdEnum field, String fieldName) {
+        return Collections.singletonMap(
+                field,
+                new FieldMetaData(
+                        fieldName,
+                        TFieldRequirementType.DEFAULT,
+                        new StructMetaData(TType.STRUCT, TestObject.class)
+                )
+        );
+    }
+
+    private static class BinaryCapturingHandler implements StructHandler<byte[]> {
+        private byte[] binaryValue;
+
+        @Override
+        public void beginStruct(int size) {
+        }
+
+        @Override
+        public void endStruct() {
+        }
+
+        @Override
+        public void beginList(int size) {
+        }
+
+        @Override
+        public void endList() {
+        }
+
+        @Override
+        public void beginSet(int size) {
+        }
+
+        @Override
+        public void endSet() {
+        }
+
+        @Override
+        public void beginMap(int size) {
+        }
+
+        @Override
+        public void endMap() {
+        }
+
+        @Override
+        public void beginKey() {
+        }
+
+        @Override
+        public void endKey() {
+        }
+
+        @Override
+        public void beginValue() {
+        }
+
+        @Override
+        public void endValue() {
+        }
+
+        @Override
+        public void name(String name) {
+        }
+
+        @Override
+        public void value(boolean value) {
+        }
+
+        @Override
+        public void value(String value) {
+        }
+
+        @Override
+        public void value(double value) {
+        }
+
+        @Override
+        public void value(long value) {
+        }
+
+        @Override
+        public void value(byte[] value) {
+            if (binaryValue == null) {
+                binaryValue = value;
+            }
+        }
+
+        @Override
+        public void nullValue() {
+        }
+
+        @Override
+        public byte[] getResult() {
+            return binaryValue;
+        }
     }
 
 }

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessorTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/tbase/TBaseProcessorTest.java
@@ -1,24 +1,16 @@
 package dev.vality.geck.serializer.kit.tbase;
 
 import dev.vality.geck.serializer.domain.*;
+import dev.vality.geck.serializer.handler.BinaryCapturingHandler;
 import dev.vality.geck.serializer.handler.HandlerStub;
 import dev.vality.geck.serializer.kit.mock.MockTBaseProcessor;
-import dev.vality.geck.serializer.StructHandler;
 import org.junit.Assert;
 import org.junit.Test;
-import org.apache.thrift.TBase;
-import org.apache.thrift.TFieldIdEnum;
-import org.apache.thrift.TFieldRequirementType;
-import org.apache.thrift.meta_data.FieldMetaData;
-import org.apache.thrift.meta_data.StructMetaData;
-import org.apache.thrift.protocol.TType;
-import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Map;
 import java.util.List;
 
 import static dev.vality.geck.serializer.GeckTestUtil.getTestObject;
@@ -96,135 +88,18 @@ public class TBaseProcessorTest {
         BinaryCapturingHandler handler = new BinaryCapturingHandler();
         new TBaseProcessor().process(binaryTest, handler);
 
-        Assert.assertArrayEquals(new byte[]{1, 2}, handler.binaryValue);
+        Assert.assertArrayEquals(new byte[]{1, 2}, handler.getResult());
     }
 
     @Test
     public void cyclicThriftGraphShouldFailFastInsteadOfStackOverflow() {
-        TBase first = Mockito.mock(TBase.class);
-        TBase second = Mockito.mock(TBase.class);
-        TFieldIdEnum firstField = mockStructField((short) 1, "next");
-        TFieldIdEnum secondField = mockStructField((short) 1, "next");
-
-        Mockito.when(first.getFields()).thenReturn(new TFieldIdEnum[]{firstField});
-        Mockito.when(first.getFieldMetaData()).thenReturn(singleStructFieldMeta(firstField, "next"));
-        Mockito.when(first.isSet(firstField)).thenReturn(true);
-        Mockito.when(first.getFieldValue(firstField)).thenReturn(second);
-
-        Mockito.when(second.getFields()).thenReturn(new TFieldIdEnum[]{secondField});
-        Mockito.when(second.getFieldMetaData()).thenReturn(singleStructFieldMeta(secondField, "next"));
-        Mockito.when(second.isSet(secondField)).thenReturn(true);
-        Mockito.when(second.getFieldValue(secondField)).thenReturn(first);
+        RecursiveStruct first = new RecursiveStruct();
+        RecursiveStruct second = new RecursiveStruct();
+        first.setNext(second);
+        second.setNext(first);
 
         assertThatThrownBy(() -> new TBaseProcessor().process(first, new HandlerStub()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Cyclic reference detected");
     }
-
-    private static TFieldIdEnum mockStructField(short id, String name) {
-        TFieldIdEnum field = Mockito.mock(TFieldIdEnum.class);
-        Mockito.when(field.getThriftFieldId()).thenReturn(id);
-        Mockito.when(field.getFieldName()).thenReturn(name);
-        return field;
-    }
-
-    private static Map<TFieldIdEnum, FieldMetaData> singleStructFieldMeta(TFieldIdEnum field, String fieldName) {
-        return Collections.singletonMap(
-                field,
-                new FieldMetaData(
-                        fieldName,
-                        TFieldRequirementType.DEFAULT,
-                        new StructMetaData(TType.STRUCT, TestObject.class)
-                )
-        );
-    }
-
-    private static class BinaryCapturingHandler implements StructHandler<byte[]> {
-        private byte[] binaryValue;
-
-        @Override
-        public void beginStruct(int size) {
-        }
-
-        @Override
-        public void endStruct() {
-        }
-
-        @Override
-        public void beginList(int size) {
-        }
-
-        @Override
-        public void endList() {
-        }
-
-        @Override
-        public void beginSet(int size) {
-        }
-
-        @Override
-        public void endSet() {
-        }
-
-        @Override
-        public void beginMap(int size) {
-        }
-
-        @Override
-        public void endMap() {
-        }
-
-        @Override
-        public void beginKey() {
-        }
-
-        @Override
-        public void endKey() {
-        }
-
-        @Override
-        public void beginValue() {
-        }
-
-        @Override
-        public void endValue() {
-        }
-
-        @Override
-        public void name(String name) {
-        }
-
-        @Override
-        public void value(boolean value) {
-        }
-
-        @Override
-        public void value(String value) {
-        }
-
-        @Override
-        public void value(double value) {
-        }
-
-        @Override
-        public void value(long value) {
-        }
-
-        @Override
-        public void value(byte[] value) {
-            if (binaryValue == null) {
-                binaryValue = value;
-            }
-        }
-
-        @Override
-        public void nullValue() {
-        }
-
-        @Override
-        public byte[] getResult() {
-            return binaryValue;
-        }
-    }
-
 }

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/xml/XMLTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/xml/XMLTest.java
@@ -2,6 +2,9 @@ package dev.vality.geck.serializer.kit.xml;
 
 import com.rbkmoney.damsel.v130.payment_processing.InvoicePaymentStarted;
 import dev.vality.geck.serializer.GeckTestUtil;
+import dev.vality.geck.serializer.exception.BadFormatException;
+import dev.vality.geck.serializer.handler.HandlerStub;
+import dev.vality.geck.serializer.kit.StructType;
 import dev.vality.geck.serializer.kit.mock.FixedValueGenerator;
 import dev.vality.geck.serializer.kit.mock.MockMode;
 import dev.vality.geck.serializer.kit.mock.MockTBaseProcessor;
@@ -10,8 +13,14 @@ import dev.vality.geck.serializer.kit.tbase.TBaseProcessor;
 import dev.vality.geck.serializer.domain.TestObject;
 import org.junit.Assert;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.dom.DOMResult;
 import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class XMLTest {
     @Test
@@ -31,5 +40,24 @@ public class XMLTest {
         //test re-use handler
         new TBaseProcessor().process(invoice, handler);
         System.out.println(xml);
+    }
+
+    @Test
+    public void unknownNodeTypeShouldFailFast() throws Exception {
+        Document document = DocumentBuilderFactory.newInstance()
+                .newDocumentBuilder()
+                .newDocument();
+        Element root = document.createElement(XMLConstants.ROOT);
+        root.setAttribute(XMLConstants.ATTRIBUTE_TYPE, StructType.STRUCT.getKey());
+        document.appendChild(root);
+        Element child = document.createElement("field");
+        child.setAttribute(XMLConstants.ATTRIBUTE_TYPE, "unsupported");
+        root.appendChild(child);
+
+        DOMResult domResult = new DOMResult(document);
+
+        assertThatThrownBy(() -> new XMLProcessor().process(domResult, new HandlerStub()))
+                .isInstanceOf(BadFormatException.class)
+                .hasMessageContaining("Attribute 'type' must not be null");
     }
 }

--- a/serializer/src/test/java/dev/vality/geck/serializer/kit/xml/XMLTest.java
+++ b/serializer/src/test/java/dev/vality/geck/serializer/kit/xml/XMLTest.java
@@ -2,6 +2,7 @@ package dev.vality.geck.serializer.kit.xml;
 
 import com.rbkmoney.damsel.v130.payment_processing.InvoicePaymentStarted;
 import dev.vality.geck.serializer.GeckTestUtil;
+import dev.vality.geck.serializer.domain.TestObject;
 import dev.vality.geck.serializer.exception.BadFormatException;
 import dev.vality.geck.serializer.handler.HandlerStub;
 import dev.vality.geck.serializer.kit.StructType;
@@ -10,7 +11,6 @@ import dev.vality.geck.serializer.kit.mock.MockMode;
 import dev.vality.geck.serializer.kit.mock.MockTBaseProcessor;
 import dev.vality.geck.serializer.kit.tbase.TBaseHandler;
 import dev.vality.geck.serializer.kit.tbase.TBaseProcessor;
-import dev.vality.geck.serializer.domain.TestObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -42,6 +42,10 @@ public class XMLTest {
         System.out.println(xml);
     }
 
+    /**
+     * Проверяет, что XML с неподдерживаемым типом узла падает сразу.
+     * Без этого некорректный XML проходил глубже в парсер и ломался уже в полусобранном состоянии.
+     */
     @Test
     public void unknownNodeTypeShouldFailFast() throws Exception {
         Document document = DocumentBuilderFactory.newInstance()


### PR DESCRIPTION
Стабилизируем `serializer` и `migrator` в тех местах, где библиотека вела себя непредсказуемо на сложных данных. Несколько исправлений: циклические thrift-структуры, рекурсивные схемы при генерации mock-объектов, передача данных через цепочку миграций и разбор некорректного входа в разных представлениях. Раньше такие случаи могли заканчиваться переполнением стека, бесконечным обходом структуры или просто неверной обработкой данных, поэтому задача этого патча именно в том, чтобы сделать поведение явным и безопасным.

В `TBaseProcessor` добавлена проверка на зацикленные ссылки, в `MockTBaseProcessor` такая же защита появилась для рекурсивных thrift-схем,  в `BaseMigrationManager` исправлена логика последовательной миграции, чтобы каждый следующий шаг получал уже преобразованный результат предыдущего шага. Заодно приведена в порядок обработка отдельных пограничных случаев в `ObjectProcessor`, `JsonProcessor` и `XMLProcessor`: исправлено чтение `ByteBuffer`, убран ошибочный проход мимо ветки `SET`, и для неизвестных типов библиотека теперь сразу сообщает об ошибке понятным исключением. 